### PR TITLE
Fix state endpoint action retrieval and host assignment

### DIFF
--- a/oRPG.py
+++ b/oRPG.py
@@ -182,7 +182,7 @@ async def get_state(player_id: Optional[str] = None):
     active = GAME.active_players()
     you = GAME.players.get(player_id) if player_id else None
     is_host = bool(you and GAME.host_id == you.id)   # <— NEW
-#    your_action = GAME.current_actions.get(player_id, "") if player_id else ""
+    your_action = GAME.current_actions.get(player_id, "") if player_id else ""
     return {
         "turn": GAME.turn_number,
         "scenario": GAME.current_scenario,
@@ -217,6 +217,8 @@ async def join(req: Request):
 
     p = Player(name, background, power, abilities)
     GAME.players[p.id] = p
+    if GAME.host_id is None:
+        GAME.host_id = p.id
 
     # if this is the first player, spin up an initial scene (lock-protected)
     if GAME.turn_number == 0 and not GAME.current_scenario:


### PR DESCRIPTION
## Summary
- Restore `your_action` retrieval in `/state` to prevent runtime errors.
- Assign `host_id` when the first player joins so host-only resolution works.

## Testing
- `python -m py_compile oRPG.py`


------
https://chatgpt.com/codex/tasks/task_e_68bc0e3892448326a1ed826e1a88f8ee