### PR TITLE
Add ability tier and signature tests

### DIFF
--- a/tests/test_abilities.py
+++ b/tests/test_abilities.py
@@ -1,0 +1,18 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from oRPG import abilities_for_archetype
+
+
+def test_abilities_tier_and_signature_truncation():
+    bg = "A wandering mage seeking knowledge." + "x" * 80
+    abilities = abilities_for_archetype("Mage", 0.5, bg)
+    assert abilities[0].startswith("Novice"), abilities
+    assert abilities[-1] == f"Signature: {bg.splitlines()[0][:60]}"
+    assert len(abilities) == 4
+
+    abilities_mid = abilities_for_archetype("Mage", 1.0, bg)
+    assert abilities_mid[0].startswith("Seasoned"), abilities_mid
+
+    abilities_high = abilities_for_archetype("Mage", 1.1, bg)
+    assert abilities_high[0].startswith("Expert"), abilities_high


### PR DESCRIPTION
## Summary
- add tests for `abilities_for_archetype` ensuring correct tier selection and signature truncation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc1fabaa088326afed008c6eb187b6