### PR TITLE
test: add coverage for archetype detection

### DIFF
--- a/tests/test_archetype.py
+++ b/tests/test_archetype.py
@@ -1,0 +1,18 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import pytest
+
+from oRPG import archetype_for_background
+
+
+@pytest.mark.parametrize("bg,expected", [
+    ("Mystic sorceress exploring ruins", "Mage"),
+    ("Silent THIEF from the city", "Rogue"),
+    ("An elven archer guarding the forest", "Ranger"),
+    ("Devout priest spreading light", "Cleric"),
+    ("BARBARIAN warrior of the north", "Warrior"),
+    ("A simple farmer with no special training", "Adventurer"),
+])
+def test_archetype_for_background(bg, expected):
+    assert archetype_for_background(bg) == expected


### PR DESCRIPTION
## Summary
- add parametrized tests for `archetype_for_background` to ensure correct class inference

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc2033541c8326a9140c7f3ab21841