### PR TITLE
Add party snapshot test coverage

### DIFF
--- a/tests/test_party_snapshot.py
+++ b/tests/test_party_snapshot.py
@@ -1,0 +1,19 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import oRPG
+
+
+def test_party_snapshot_formats_and_handles_empty():
+    # empty party
+    assert oRPG.party_snapshot([]) == "(no one yet)"
+
+    # populated party formatting
+    p1 = oRPG.Player("Alice", "brave warrior", 1.0, ["Slash", "Shield Bash"])
+    p2 = oRPG.Player("Bob", "stealthy rogue", 0.9, ["Sneak", "Backstab"])
+    result = oRPG.party_snapshot([p1, p2])
+    expected = (
+        f"- {p1.name} ({p1.power}x power) – Warrior; Abilities: Slash, Shield Bash\n"
+        f"- {p2.name} ({p2.power}x power) – Rogue; Abilities: Sneak, Backstab"
+    )
+    assert result == expected


### PR DESCRIPTION
## Summary
- add missing tests for `party_snapshot`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc2681d73483269107ffaf506650ce