### PR TITLE
Add test for join power averaging

### DIFF
--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -2,6 +2,7 @@ import sys, pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import oRPG
+import time
 from fastapi.testclient import TestClient
 
 
@@ -61,3 +62,29 @@ def test_join_requires_name_and_background(monkeypatch):
     assert resp2.status_code == 400
     assert g.players == {}
     assert g.host_id is None
+
+
+def test_join_power_averages_active_players(monkeypatch):
+    g = oRPG.Game()
+    now = time.time()
+    p1 = oRPG.Player("Alice", "warrior", 1.2, [])
+    p2 = oRPG.Player("Bob", "rogue", 0.8, [])
+    stale = oRPG.Player("Carol", "wizard", 10.0, [])
+    p1.last_seen = now
+    p2.last_seen = now
+    stale.last_seen = now - 1000
+    g.players = {p1.id: p1, p2.id: p2, stale.id: stale}
+    g.host_id = p1.id
+    g.turn_number = 1
+    g.current_scenario = "scene"
+    monkeypatch.setattr(oRPG, "GAME", g)
+    monkeypatch.setattr(oRPG, "JOIN_CODE", "")
+
+    client = TestClient(oRPG.app)
+
+    resp = client.post("/join", json={"name": "Dana", "background": "brave hero"})
+    assert resp.status_code == 200
+    new_id = resp.json()["player_id"]
+    new_player = g.players[new_id]
+    assert new_player.power == 1.0
+    assert new_player.power != (1.2 + 0.8 + 10.0) / 3


### PR DESCRIPTION
## Summary
- add regression test ensuring join uses active players' average power and ignores stale ones

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc80715fe48326b94f1204d4090403