### PR TITLE
Add tests for prompt builder functions

### DIFF
--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -1,0 +1,23 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import oRPG
+
+
+def test_initial_scene_user_message_includes_inputs_and_defaults():
+    msg = oRPG.initial_scene_user_message("", "- Alice")
+    # ensures default summary placeholder and party roster are included
+    assert "START A NEW SCENE." in msg
+    assert "(none)" in msg
+    assert "- Alice" in msg
+    assert "— What do you do?" in msg
+
+
+def test_resolution_user_message_includes_all_sections():
+    msg = oRPG.resolution_user_message("facts", "- Bob", "a scenario", "- Bob: acts")
+    assert "RESOLVE THE PARTY'S ACTIONS" in msg
+    assert "facts" in msg
+    assert "a scenario" in msg
+    assert "- Bob" in msg
+    assert "- Bob: acts" in msg
+    assert "— What do you do?" in msg


### PR DESCRIPTION
## Summary
- cover initial_scene_user_message to ensure default summary and party roster are included
- test resolution_user_message for presence of summary, scenario, party, actions and closing prompt

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc82430fdc8326ad19d075f81b00e0