### PR TITLE
Add test for resolution game state updates

### DIFF
--- a/tests/test_do_resolution.py
+++ b/tests/test_do_resolution.py
@@ -1,0 +1,35 @@
+import sys, pathlib, asyncio
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import oRPG
+
+
+def test_do_resolution_updates_game_state(monkeypatch):
+    g = oRPG.Game()
+    player = oRPG.Player("Alice", "brave hero", 1.0, [])
+    g.players = {player.id: player}
+    g.turn_number = 1
+    g.current_scenario = "A dragon blocks the path."
+    g.current_actions = {player.id: "attack"}
+    g.last_summary = "They set out from town."
+    monkeypatch.setattr(oRPG, "GAME", g)
+
+    async def fake_ollama_chat(messages, options=None):
+        if messages and messages[0].get("content") == oRPG.GM_SYSTEM_PROMPT:
+            return "The dragon falls. — What do you do?"
+        return "The party defeated a dragon."
+
+    monkeypatch.setattr(oRPG, "ollama_chat", fake_ollama_chat)
+
+    asyncio.run(oRPG.do_resolution())
+
+    assert g.turn_number == 2
+    assert g.current_scenario == "The dragon falls. — What do you do?"
+    assert g.last_summary == "The party defeated a dragon."
+    assert g.current_actions == {}
+    assert len(g.history) == 1
+    hist = g.history[0]
+    assert hist["turn"] == 1
+    assert hist["scenario"] == "A dragon blocks the path."
+    assert hist["actions"] == {player.id: "attack"}
+    assert "The dragon falls" in hist["narration"]


### PR DESCRIPTION
## Summary
- cover `do_resolution` to ensure game state and history update correctly

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc834c00a4832683c72d6d0591eba0