### PR TITLE
Refactor last_seen assertions in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,14 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+from fastapi.testclient import TestClient
+import oRPG
+
+
+def assert_last_seen_updates(client: TestClient, player: oRPG.Player, method: str, url: str, **kwargs):
+    """Hit an endpoint and assert the player's last_seen is updated."""
+    player.last_seen = 0
+    response = client.request(method, url, **kwargs)
+    assert response.status_code == 200
+    assert player.last_seen > 0
+    return response

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -3,6 +3,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import oRPG
 from fastapi.testclient import TestClient
+from tests.conftest import assert_last_seen_updates
 
 
 def test_submit_action_stores_truncates_and_clears(monkeypatch):
@@ -35,12 +36,10 @@ def test_submit_action_requires_valid_player():
 def test_submit_action_updates_last_seen(monkeypatch):
     g = oRPG.Game()
     player = oRPG.Player("Alice", "hero", 1.0, [])
-    player.last_seen = 0
     g.players = {player.id: player}
     monkeypatch.setattr(oRPG, "GAME", g)
 
     client = TestClient(oRPG.app)
-
-    resp = client.post("/action", json={"player_id": player.id, "text": "attack"})
-    assert resp.status_code == 200
-    assert player.last_seen > 0
+    assert_last_seen_updates(
+        client, player, "post", "/action", json={"player_id": player.id, "text": "attack"}
+    )

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -3,6 +3,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import oRPG
 from fastapi.testclient import TestClient
+from tests.conftest import assert_last_seen_updates
 
 
 def test_state_includes_flags_and_updates_last_seen(monkeypatch):
@@ -22,25 +23,22 @@ def test_state_includes_flags_and_updates_last_seen(monkeypatch):
 
     client = TestClient(oRPG.app)
 
-    host.last_seen = 0
-    resp = client.get("/state", params={"player_id": host.id})
-    assert resp.status_code == 200
+    resp = assert_last_seen_updates(
+        client, host, "get", "/state", params={"player_id": host.id}
+    )
     data = resp.json()
     assert data["is_host"] is True
     assert data["your_action"] == "look"
     assert data["can_resolve"] is True
     assert data["join_code_required"] is True
-    assert host.last_seen > 0
-
-    other.last_seen = 0
-    resp2 = client.get("/state", params={"player_id": other.id})
-    assert resp2.status_code == 200
+    resp2 = assert_last_seen_updates(
+        client, other, "get", "/state", params={"player_id": other.id}
+    )
     data2 = resp2.json()
     assert data2["is_host"] is False
     assert data2["your_action"] == "hide"
     assert data2["can_resolve"] is False
     assert data2["join_code_required"] is True
-    assert other.last_seen > 0
 
 def test_state_can_resolve_when_anyone_allowed(monkeypatch):
     g = oRPG.Game()


### PR DESCRIPTION
## Summary
- add assert_last_seen_updates helper for exercising endpoints and verifying last_seen
- use helper in action and state tests to remove duplicate timestamp checks

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc8dc569c08326a561da7f8e64e1a7