### PR TITLE
Consolidate resolve/state tests

### DIFF
--- a/tests/test_allow_anyone_to_resolve.py
+++ b/tests/test_allow_anyone_to_resolve.py
@@ -1,0 +1,54 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import oRPG
+import pytest
+from fastapi.testclient import TestClient
+
+
+@pytest.mark.parametrize(
+    "endpoint,method,expected_key,expect_called",
+    [
+        ("/resolve", "post", "ok", True),
+        ("/state", "get", "can_resolve", False),
+    ],
+)
+def test_anyone_can_resolve_or_view_state(
+    monkeypatch, endpoint, method, expected_key, expect_called
+):
+    g = oRPG.Game()
+    host = oRPG.Player("Host", "leader", 1.0, [])
+    other = oRPG.Player("Other", "member", 1.0, [])
+    g.players = {host.id: host, other.id: other}
+    g.host_id = host.id
+    g.turn_number = 1
+    g.current_scenario = "scene"
+
+    monkeypatch.setattr(oRPG, "GAME", g)
+    monkeypatch.setattr(oRPG, "ALLOW_ANYONE_TO_RESOLVE", True)
+
+    if expect_called:
+        called = {"flag": False}
+
+        async def fake_do_resolution():
+            called["flag"] = True
+
+        monkeypatch.setattr(oRPG, "do_resolution", fake_do_resolution)
+    else:
+        called = None
+
+    client = TestClient(oRPG.app)
+
+    payload = {"player_id": other.id}
+    if method == "post":
+        resp = client.post(endpoint, json=payload)
+    else:
+        resp = client.get(endpoint, params=payload)
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data[expected_key] is True
+
+    if expect_called:
+        assert called["flag"] is True
+

--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -37,34 +37,6 @@ def test_resolve_requires_host(monkeypatch):
     assert resp2.json()["ok"] is True
     assert called["flag"] is True
 
-
-def test_resolve_allows_anyone_when_enabled(monkeypatch):
-    g = oRPG.Game()
-    host = oRPG.Player("Host", "leader", 1.0, [])
-    other = oRPG.Player("Other", "member", 1.0, [])
-    g.players = {host.id: host, other.id: other}
-    g.host_id = host.id
-    g.turn_number = 1
-    g.current_scenario = "scene"
-
-    monkeypatch.setattr(oRPG, "GAME", g)
-    monkeypatch.setattr(oRPG, "ALLOW_ANYONE_TO_RESOLVE", True)
-
-    called = {"flag": False}
-
-    async def fake_do_resolution():
-        called["flag"] = True
-
-    monkeypatch.setattr(oRPG, "do_resolution", fake_do_resolution)
-
-    client = TestClient(oRPG.app)
-
-    # non-host can resolve when allowed
-    resp = client.post("/resolve", json={"player_id": other.id})
-    assert resp.status_code == 200
-    assert resp.json()["ok"] is True
-    assert called["flag"] is True
-
 def test_resolve_rejects_when_already_resolving(monkeypatch):
     g = oRPG.Game()
     host = oRPG.Player("Host", "leader", 1.0, [])

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -41,21 +41,3 @@ def test_state_includes_flags_and_updates_last_seen(monkeypatch):
     assert data2["can_resolve"] is False
     assert data2["join_code_required"] is True
     assert other.last_seen > 0
-
-def test_state_can_resolve_when_anyone_allowed(monkeypatch):
-    g = oRPG.Game()
-    host = oRPG.Player("Host", "leader", 1.0, [])
-    other = oRPG.Player("Other", "member", 1.0, [])
-    g.players = {host.id: host, other.id: other}
-    g.host_id = host.id
-    g.turn_number = 1
-    g.current_scenario = "scene"
-
-    monkeypatch.setattr(oRPG, "GAME", g)
-    monkeypatch.setattr(oRPG, "ALLOW_ANYONE_TO_RESOLVE", True)
-
-    client = TestClient(oRPG.app)
-    resp = client.get("/state", params={"player_id": other.id})
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data["can_resolve"] is True


### PR DESCRIPTION
## Summary
- combine /resolve and /state tests into a single parameterized test when anyone can resolve
- drop redundant endpoint-specific tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc8da87c9083268453052671def520