### PR TITLE
Implement player leave endpoint with host reassignment

### DIFF
--- a/oRPG.py
+++ b/oRPG.py
@@ -240,6 +240,23 @@ async def submit_action(req: Request):
     GAME.players[pid].last_seen = time.time()
     return {"ok": True}
 
+@app.post("/leave")
+async def leave(req: Request):
+    data = await req.json()
+    pid = data.get("player_id")
+    if not pid or pid not in GAME.players:
+        return JSONResponse({"error": "Invalid player."}, status_code=400)
+
+    GAME.current_actions.pop(pid, None)
+    departing_host = pid == GAME.host_id
+    del GAME.players[pid]
+
+    if departing_host:
+        active = GAME.active_players()
+        GAME.host_id = active[0].id if active else None
+
+    return {"ok": True}
+
 @app.post("/resolve")
 async def resolve_turn(req: Request):
     if GAME.resolving:
@@ -424,6 +441,7 @@ footer{margin-top:20px;color:#7b8b9b}
           <button id="submitBtn" onclick="submitAction()">Submit / Update</button>
           <button class="secondary" onclick="clearAction()">Clear</button>
           <button id="resolveBtn" class="secondary" style="display:none" onclick="resolveNow()">Resolve turn</button>
+          <button id="leaveBtn" class="secondary" onclick="leaveGame()">Leave game</button>
         </div>
       </section>
 
@@ -599,6 +617,25 @@ async function clearAction(){
     refresh();
   }finally{
     busy(false);
+  }
+}
+
+async function leaveGame(){
+  if(!S.player_id) return;
+  btnBusy("leaveBtn", true, "Leaving...");
+  busy(true);
+  try{
+    await api("/leave", {method:"POST", body: JSON.stringify({player_id: S.player_id})});
+  }catch(e){
+    console.warn(e);
+  }finally{
+    S.player_id = "";
+    localStorage.removeItem("player_id");
+    show("join", true);
+    show("game", false);
+    busy(false);
+    btnBusy("leaveBtn", false);
+    refresh();
   }
 }
 

--- a/tests/test_leave.py
+++ b/tests/test_leave.py
@@ -1,0 +1,56 @@
+import sys, pathlib, time
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import oRPG
+from fastapi.testclient import TestClient
+
+
+def test_leave_removes_player(monkeypatch):
+    g = oRPG.Game()
+    p1 = oRPG.Player("Alice", "warrior", 1.0, [])
+    p2 = oRPG.Player("Bob", "rogue", 1.0, [])
+    now = time.time()
+    p1.last_seen = now
+    p2.last_seen = now
+    g.players = {p1.id: p1, p2.id: p2}
+    g.host_id = p1.id
+    monkeypatch.setattr(oRPG, "GAME", g)
+
+    client = TestClient(oRPG.app)
+    resp = client.post("/leave", json={"player_id": p2.id})
+    assert resp.status_code == 200
+    assert p2.id not in g.players
+    assert g.host_id == p1.id
+
+
+def test_leave_reassigns_host(monkeypatch):
+    g = oRPG.Game()
+    p1 = oRPG.Player("Alice", "warrior", 1.0, [])
+    p2 = oRPG.Player("Bob", "rogue", 1.0, [])
+    now = time.time()
+    p1.last_seen = now
+    p2.last_seen = now
+    g.players = {p1.id: p1, p2.id: p2}
+    g.host_id = p1.id
+    monkeypatch.setattr(oRPG, "GAME", g)
+
+    client = TestClient(oRPG.app)
+    resp = client.post("/leave", json={"player_id": p1.id})
+    assert resp.status_code == 200
+    assert p1.id not in g.players
+    assert g.host_id == p2.id
+
+
+def test_leave_last_player_clears_host(monkeypatch):
+    g = oRPG.Game()
+    p1 = oRPG.Player("Alice", "warrior", 1.0, [])
+    p1.last_seen = time.time()
+    g.players = {p1.id: p1}
+    g.host_id = p1.id
+    monkeypatch.setattr(oRPG, "GAME", g)
+
+    client = TestClient(oRPG.app)
+    resp = client.post("/leave", json={"player_id": p1.id})
+    assert resp.status_code == 200
+    assert g.players == {}
+    assert g.host_id is None


### PR DESCRIPTION
## Summary
- add `/leave` endpoint to remove players and reassign host
- add client-side leave button clearing stored player ID
- add tests covering player removal and host reassignment

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bc8e8cfe3083268f73a91396e00211