### PR TITLE
await refresh after submitting actions

### DIFF
--- a/oRPG.py
+++ b/oRPG.py
@@ -600,7 +600,7 @@ async function submitAction(){
   try{
     await api("/action", {method:"POST", body: JSON.stringify({player_id: S.player_id, text})});
     S.actionDirty = false;
-    refresh();
+    await refresh();
   }finally{
     busy(false);
     btnBusy("submitBtn", false);
@@ -614,7 +614,7 @@ async function clearAction(){
     await api("/action", {method:"POST", body: JSON.stringify({player_id: S.player_id, text: ""})});
     qs("action").value = "";
     S.actionDirty = false;
-    refresh();
+    await refresh();
   }finally{
     busy(false);
   }


### PR DESCRIPTION
## Summary
- await the state refresh after submitting or clearing an action so the button stays busy until the update completes

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bc9051ed38832682c432b4f67a0e19