### PR TITLE
test: cover root HTML page

### DIFF
--- a/tests/test_root_html.py
+++ b/tests/test_root_html.py
@@ -1,0 +1,14 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import oRPG
+from fastapi.testclient import TestClient
+
+
+def test_root_returns_single_page_html():
+    client = TestClient(oRPG.app)
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert resp.headers["content-type"].startswith("text/html")
+    assert "<!doctype html>" in resp.text.lower()
+    assert "Ollama Fantasy Party" in resp.text


### PR DESCRIPTION
## Summary
- add test ensuring GET / serves the single-page HTML with "Ollama Fantasy Party" marker

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd408ae5888326ba2f9e5697c00054