### PR TITLE
Add case-insensitive tests for ranger synonyms

### DIFF
--- a/tests/test_archetype.py
+++ b/tests/test_archetype.py
@@ -16,3 +16,8 @@ from oRPG import archetype_for_background
 ])
 def test_archetype_for_background(bg, expected):
     assert archetype_for_background(bg) == expected
+
+
+@pytest.mark.parametrize("bg", ["RANGER", "HUNTER", "ARCHER"])
+def test_ranger_synonyms_case_insensitive(bg):
+    assert archetype_for_background(bg) == "Ranger"


### PR DESCRIPTION
## Summary
- test archetype_for_background maps ranger/hunter/archer to Ranger regardless of case

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd419995cc832685e7ebbc5dc885ac