### PR TITLE
Add case-insensitive cleric mapping test

### DIFF
--- a/tests/test_archetype.py
+++ b/tests/test_archetype.py
@@ -16,3 +16,12 @@ from oRPG import archetype_for_background
 ])
 def test_archetype_for_background(bg, expected):
     assert archetype_for_background(bg) == expected
+
+
+@pytest.mark.parametrize("bg", [
+    "cLeRiC",
+    "PrIeSt",
+    "pALaDiN",
+])
+def test_cleric_variations(bg):
+    assert archetype_for_background(bg) == "Cleric"


### PR DESCRIPTION
## Summary
- test `archetype_for_background` with varying case for cleric synonyms

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd419ff62083268fb0c19e57898e8b