### PR TITLE
test: check warrior keywords case-insensitively

### DIFF
--- a/tests/test_archetype.py
+++ b/tests/test_archetype.py
@@ -16,3 +16,8 @@ from oRPG import archetype_for_background
 ])
 def test_archetype_for_background(bg, expected):
     assert archetype_for_background(bg) == expected
+
+
+@pytest.mark.parametrize("bg", ["barbarian", "FIGHTER", "Knight", "warrior"])
+def test_archetype_warrior_keywords_case_insensitive(bg):
+    assert archetype_for_background(bg) == "Warrior"


### PR DESCRIPTION
## Summary
- ensure `archetype_for_background` treats warrior-related terms case-insensitively

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bd41a57e208326aab34be1a0b2b73a