### PR TITLE
Add test for default archetype with no keywords

### DIFF
--- a/tests/test_archetype.py
+++ b/tests/test_archetype.py
@@ -13,6 +13,7 @@ from oRPG import archetype_for_background
     ("Devout priest spreading light", "Cleric"),
     ("BARBARIAN warrior of the north", "Warrior"),
     ("A simple farmer with no special training", "Adventurer"),
+    ("", "Adventurer"),
 ])
 def test_archetype_for_background(bg, expected):
     assert archetype_for_background(bg) == expected


### PR DESCRIPTION
## Summary
- add test case ensuring empty backgrounds default to Adventurer archetype

## Testing
- `pytest tests/test_archetype.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd41a91570832696c69cf67c37bef7