### PR TITLE
Ensure signature ability uses first background line

### DIFF
--- a/tests/test_abilities.py
+++ b/tests/test_abilities.py
@@ -16,3 +16,10 @@ def test_abilities_tier_and_signature_truncation():
 
     abilities_high = abilities_for_archetype("Mage", 1.1, bg)
     assert abilities_high[0].startswith("Expert"), abilities_high
+
+
+def test_abilities_signature_first_line_and_length():
+    bg = "First line of background.\nSecond line should be ignored."
+    abilities = abilities_for_archetype("Rogue", 0.9, bg)
+    assert len(abilities) == 4
+    assert abilities[-1] == f"Signature: {bg.splitlines()[0][:60]}"


### PR DESCRIPTION
## Summary
- test that abilities_for_archetype returns four abilities with a Signature derived from the first background line

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd41ad5a908326a92b594da0a4454a