### PR TITLE
test: cover ability tier boundaries

### DIFF
--- a/tests/test_abilities.py
+++ b/tests/test_abilities.py
@@ -16,3 +16,11 @@ def test_abilities_tier_and_signature_truncation():
 
     abilities_high = abilities_for_archetype("Mage", 1.1, bg)
     assert abilities_high[0].startswith("Expert"), abilities_high
+
+
+def test_abilities_tier_boundaries():
+    bg = "Any background"
+    assert abilities_for_archetype("Mage", 0.94, bg)[0].startswith("Novice")
+    assert abilities_for_archetype("Mage", 0.95, bg)[0].startswith("Seasoned")
+    assert abilities_for_archetype("Mage", 1.04, bg)[0].startswith("Seasoned")
+    assert abilities_for_archetype("Mage", 1.05, bg)[0].startswith("Expert")


### PR DESCRIPTION
## Summary
- add tests checking ability tier boundaries for Novice, Seasoned, and Expert

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd41b2607c83268ad69d2c4bc58c5a