### PR TITLE
Add deterministic abilities order test

### DIFF
--- a/tests/test_abilities.py
+++ b/tests/test_abilities.py
@@ -16,3 +16,20 @@ def test_abilities_tier_and_signature_truncation():
 
     abilities_high = abilities_for_archetype("Mage", 1.1, bg)
     assert abilities_high[0].startswith("Expert"), abilities_high
+
+
+def test_abilities_order_before_signature():
+    bg = "An intrepid adventurer."
+    expected = {
+        "Mage": ["Seasoned Evocations", "Runic Ward", "Arcane Recall"],
+        "Rogue": ["Seasoned Stealth", "Quick Hands", "Cunning Footwork"],
+        "Ranger": ["Seasoned Marksmanship", "Trail Lore", "Animal Rapport"],
+        "Cleric": ["Seasoned Blessing", "Ward of Light", "Soothing Prayer"],
+        "Warrior": ["Seasoned Weapon Mastery", "Shieldwork", "Battle Cry"],
+        "Adventurer": ["Seasoned Ingenuity", "Improvised Tools", "Lucky Break"],
+    }
+
+    for arche, base in expected.items():
+        abilities = abilities_for_archetype(arche, 1.0, bg)
+        assert abilities[:-1] == base
+        assert abilities[-1].startswith("Signature:")


### PR DESCRIPTION
## Summary
- add test ensuring base abilities retain defined order prior to "Signature:" ability

## Testing
- `pytest tests/test_abilities.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd41bc7644832680dab4d9e2fad718