### PR TITLE
Add detailed party_snapshot test

### DIFF
--- a/tests/test_party_snapshot.py
+++ b/tests/test_party_snapshot.py
@@ -17,3 +17,16 @@ def test_party_snapshot_formats_and_handles_empty():
         f"- {p2.name} ({p2.power}x power) – Rogue; Abilities: Sneak, Backstab"
     )
     assert result == expected
+
+
+def test_party_snapshot_includes_all_player_details():
+    players = [
+        oRPG.Player("Cara", "pious cleric", 1.2, ["Heal", "Bless"]),
+        oRPG.Player("Dan", "keen ranger", 0.8, ["Track", "Ambush"]),
+    ]
+    lines = oRPG.party_snapshot(players).splitlines()
+    for line, p in zip(lines, players):
+        assert p.name in line
+        assert f"{p.power}x power" in line
+        assert oRPG.archetype_for_background(p.background) in line
+        assert ", ".join(p.abilities) in line


### PR DESCRIPTION
## Summary
- ensure party_snapshot renders each player's name, power with `x`, archetype, and abilities list

## Testing
- `pytest tests/test_party_snapshot.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd41d264d48326a60f501080fc1b04