### PR TITLE
Add test verifying default active players window

### DIFF
--- a/tests/test_active_players.py
+++ b/tests/test_active_players.py
@@ -17,3 +17,20 @@ def test_active_players_filters_stale_entries():
     active = g.active_players(stale_seconds=60)
     assert recent in active
     assert stale not in active
+
+def test_active_players_uses_default_window():
+    g = Game()
+    inside = Player("Carol", "mighty mage", 1.0, [])
+    boundary = Player("Dave", "old ranger", 1.0, [])
+    outside = Player("Eve", "ancient cleric", 1.0, [])
+    g.players = {inside.id: inside, boundary.id: boundary, outside.id: outside}
+
+    now = time.time()
+    inside.last_seen = now - 100  # within default window
+    boundary.last_seen = now - 600  # exactly at boundary; should be excluded
+    outside.last_seen = now - 601  # outside default window
+
+    active = g.active_players()
+    assert inside in active
+    assert boundary not in active
+    assert outside not in active


### PR DESCRIPTION
## Summary
- add test to ensure Game.active_players respects default 600-second stale window

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd41f17f20832695719ba46f556eb5