### PR TITLE
Add test ensuring /state updates last_seen monotonically

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -53,3 +53,24 @@ def test_state_can_resolve_when_anyone_allowed(monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert data["can_resolve"] is True
+
+
+def test_state_last_seen_monotonic(monkeypatch):
+    import itertools
+
+    g = oRPG.Game()
+    player = oRPG.Player("Alice", "adventurer", 1.0, [])
+    g.players = {player.id: player}
+    monkeypatch.setattr(oRPG, "GAME", g)
+
+    player.last_seen = 0
+    times = itertools.count(100.0, 1.0)
+    monkeypatch.setattr(oRPG.time, "time", lambda: next(times))
+
+    client = TestClient(oRPG.app)
+    resp1 = client.get("/state", params={"player_id": player.id})
+    assert resp1.status_code == 200
+    first_seen = player.last_seen
+    resp2 = client.get("/state", params={"player_id": player.id})
+    assert resp2.status_code == 200
+    assert player.last_seen > first_seen


### PR DESCRIPTION
## Summary
- add regression test that repeated `/state` requests bump a player's `last_seen`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd41fc5a8c83268551a24cb38b266b