### PR TITLE
Add join ability archetype test

### DIFF
--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -88,3 +88,26 @@ def test_join_power_averages_active_players(monkeypatch):
     new_player = g.players[new_id]
     assert new_player.power == 1.0
     assert new_player.power != (1.2 + 0.8 + 10.0) / 3
+
+
+def test_join_assigns_abilities_based_on_background(monkeypatch):
+    g = oRPG.Game()
+    monkeypatch.setattr(oRPG, "GAME", g)
+    monkeypatch.setattr(oRPG, "JOIN_CODE", "")
+
+    async def fake_initial_scene():
+        g.turn_number = 1
+        g.current_scenario = "intro"
+
+    monkeypatch.setattr(oRPG, "ensure_initial_scene", fake_initial_scene)
+
+    client = TestClient(oRPG.app)
+    bg = "Cunning thief from the city"
+    resp = client.post("/join", json={"name": "Sneak", "background": bg})
+    assert resp.status_code == 200
+    pid = resp.json()["player_id"]
+    player = g.players[pid]
+
+    arche = oRPG.archetype_for_background(bg)
+    expected = oRPG.abilities_for_archetype(arche, player.power, bg)
+    assert player.abilities == expected


### PR DESCRIPTION
## Summary
- test that `/join` assigns abilities based on the archetype inferred from the player's background

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bd422596048326b6aa8b6e60a502a0