### PR TITLE
Add conditional initial scene test for /join

### DIFF
--- a/tests/test_join.py
+++ b/tests/test_join.py
@@ -3,6 +3,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import oRPG
 import time
+import pytest
 from fastapi.testclient import TestClient
 
 
@@ -88,3 +89,32 @@ def test_join_power_averages_active_players(monkeypatch):
     new_player = g.players[new_id]
     assert new_player.power == 1.0
     assert new_player.power != (1.2 + 0.8 + 10.0) / 3
+
+
+@pytest.mark.parametrize(
+    "turn,scenario,called",
+    [
+        (0, None, True),
+        (1, None, False),
+        (0, "scene", False),
+    ],
+)
+def test_join_triggers_initial_scene_only_when_initial(monkeypatch, turn, scenario, called):
+    g = oRPG.Game()
+    g.turn_number = turn
+    g.current_scenario = scenario
+    monkeypatch.setattr(oRPG, "GAME", g)
+    monkeypatch.setattr(oRPG, "JOIN_CODE", "")
+
+    flag = {"called": False}
+
+    async def fake_initial_scene():
+        flag["called"] = True
+
+    monkeypatch.setattr(oRPG, "ensure_initial_scene", fake_initial_scene)
+
+    client = TestClient(oRPG.app)
+
+    resp = client.post("/join", json={"name": "Alice", "background": "brave warrior"})
+    assert resp.status_code == 200
+    assert flag["called"] is called


### PR DESCRIPTION
## Summary
- add test covering when `/join` triggers `ensure_initial_scene`
- verify it only runs when the game is at its initial state

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd422afb3c8326b1c2ccd45165388b