### PR TITLE
Add test for action text trimming and last_seen update

### DIFF
--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -43,3 +43,17 @@ def test_submit_action_updates_last_seen(monkeypatch):
     assert_last_seen_updates(
         client, player, "post", "/action", json={"player_id": player.id, "text": "attack"}
     )
+
+
+def test_submit_action_trims_and_updates_last_seen(monkeypatch):
+    g = oRPG.Game()
+    player = oRPG.Player("Alice", "hero", 1.0, [])
+    g.players = {player.id: player}
+    monkeypatch.setattr(oRPG, "GAME", g)
+
+    client = TestClient(oRPG.app)
+    long_text = "  " + "x" * 600 + "  "
+    assert_last_seen_updates(
+        client, player, "post", "/action", json={"player_id": player.id, "text": long_text}
+    )
+    assert g.current_actions[player.id] == "x" * 500


### PR DESCRIPTION
## Summary
- test POST /action trims text, enforces 500 char limit, and updates last_seen

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd42346cf88326a45754a17ceb152a