### PR TITLE
Add test to clear player action on empty text

### DIFF
--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -43,3 +43,16 @@ def test_submit_action_updates_last_seen(monkeypatch):
     assert_last_seen_updates(
         client, player, "post", "/action", json={"player_id": player.id, "text": "attack"}
     )
+
+
+def test_post_action_empty_text_clears_action(monkeypatch):
+    g = oRPG.Game()
+    player = oRPG.Player("Alice", "hero", 1.0, [])
+    g.players = {player.id: player}
+    g.current_actions[player.id] = "attack"
+    monkeypatch.setattr(oRPG, "GAME", g)
+
+    client = TestClient(oRPG.app)
+    resp = client.post("/action", json={"player_id": player.id, "text": ""})
+    assert resp.status_code == 200
+    assert player.id not in g.current_actions


### PR DESCRIPTION
## Summary
- verify empty string submitted to `/action` removes player's stored action

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bd42396820832689c9e7325982c03d