### PR TITLE
Add test for invalid player ID in /resolve

### DIFF
--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -65,6 +65,30 @@ def test_resolve_allows_anyone_when_enabled(monkeypatch):
     assert resp.json()["ok"] is True
     assert called["flag"] is True
 
+
+def test_resolve_rejects_invalid_player(monkeypatch):
+    g = oRPG.Game()
+    host = oRPG.Player("Host", "leader", 1.0, [])
+    g.players = {host.id: host}
+    g.host_id = host.id
+    g.turn_number = 1
+    g.current_scenario = "scene"
+
+    monkeypatch.setattr(oRPG, "GAME", g)
+
+    called = {"flag": False}
+
+    async def fake_do_resolution():
+        called["flag"] = True
+
+    monkeypatch.setattr(oRPG, "do_resolution", fake_do_resolution)
+
+    client = TestClient(oRPG.app)
+    resp = client.post("/resolve", json={"player_id": "not-real"})
+    assert resp.status_code == 400
+    assert resp.json()["error"] == "Invalid player."
+    assert called["flag"] is False
+
 def test_resolve_rejects_when_already_resolving(monkeypatch):
     g = oRPG.Game()
     host = oRPG.Player("Host", "leader", 1.0, [])


### PR DESCRIPTION
## Summary
- add regression test: POST /resolve returns HTTP 400 for invalid player id

## Testing
- `pytest tests/test_resolve.py`


------
https://chatgpt.com/codex/tasks/task_e_68bd424480c48326b32e0636789da916