### PR TITLE
Add resolving flag test for resolve endpoint

### DIFF
--- a/tests/test_resolve.py
+++ b/tests/test_resolve.py
@@ -3,6 +3,7 @@ sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 import oRPG
 from fastapi.testclient import TestClient
+import asyncio
 
 
 def test_resolve_requires_host(monkeypatch):
@@ -113,3 +114,32 @@ def test_resolve_updates_last_seen(monkeypatch):
     assert resp.status_code == 200
     assert resp.json()["ok"] is True
     assert host.last_seen > 0
+
+
+def test_resolve_sets_and_clears_resolving(monkeypatch):
+    g = oRPG.Game()
+    host = oRPG.Player("Host", "leader", 1.0, [])
+    g.players = {host.id: host}
+    g.host_id = host.id
+    g.turn_number = 1
+    g.current_scenario = "scene"
+
+    monkeypatch.setattr(oRPG, "GAME", g)
+
+    states = []
+
+    async def fake_do_resolution():
+        states.append(oRPG.GAME.resolving)
+        await asyncio.sleep(0)
+        states.append(oRPG.GAME.resolving)
+
+    monkeypatch.setattr(oRPG, "do_resolution", fake_do_resolution)
+
+    client = TestClient(oRPG.app)
+
+    assert oRPG.GAME.resolving is False
+    resp = client.post("/resolve", json={"player_id": host.id})
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+    assert states == [True, True]
+    assert oRPG.GAME.resolving is False


### PR DESCRIPTION
## Summary
- check that POST /resolve sets and clears GAME.resolving using stubbed do_resolution

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd42538ed88326ba21a0d4b4bba5a2