### PR TITLE
Add sequential do_resolution history test

### DIFF
--- a/tests/test_do_resolution.py
+++ b/tests/test_do_resolution.py
@@ -33,3 +33,44 @@ def test_do_resolution_updates_game_state(monkeypatch):
     assert hist["scenario"] == "A dragon blocks the path."
     assert hist["actions"] == {player.id: "attack"}
     assert "The dragon falls" in hist["narration"]
+
+
+def test_do_resolution_history_and_state(monkeypatch):
+    g = oRPG.Game()
+    player = oRPG.Player("Alice", "brave hero", 1.0, [])
+    g.players = {player.id: player}
+    g.turn_number = 1
+    g.current_scenario = "A dragon blocks the path."
+    g.current_actions = {player.id: "attack"}
+    g.last_summary = "They set out from town."
+    monkeypatch.setattr(oRPG, "GAME", g)
+
+    responses = iter([
+        "The dragon falls. — What do you do?",
+        "The party defeated a dragon.",
+    ])
+
+    call_count = 0
+
+    async def fake_ollama_chat(messages, options=None):
+        nonlocal call_count
+        call_count += 1
+        return next(responses)
+
+    monkeypatch.setattr(oRPG, "ollama_chat", fake_ollama_chat)
+
+    asyncio.run(oRPG.do_resolution())
+
+    assert call_count == 2
+    assert g.turn_number == 2
+    assert g.current_scenario == "The dragon falls. — What do you do?"
+    assert g.last_summary == "The party defeated a dragon."
+    assert g.current_actions == {}
+    assert len(g.history) == 1
+    hist = g.history[0]
+    assert set(hist.keys()) == {"turn", "scenario", "actions", "narration", "ts"}
+    assert hist["turn"] == 1
+    assert hist["scenario"] == "A dragon blocks the path."
+    assert hist["actions"] == {player.id: "attack"}
+    assert hist["narration"] == "The dragon falls. — What do you do?"
+    assert isinstance(hist["ts"], str)


### PR DESCRIPTION
## Summary
- add a test ensuring `do_resolution` with sequential `ollama_chat` responses updates history and game state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd425d50c083269d75316f94ba0511