### PR TITLE
Add test for excluding stale players from state.party

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,6 +1,8 @@
 import sys, pathlib
 sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
+import time
+
 import oRPG
 from fastapi.testclient import TestClient
 from tests.conftest import assert_last_seen_updates
@@ -53,3 +55,24 @@ def test_state_can_resolve_when_anyone_allowed(monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert data["can_resolve"] is True
+
+
+def test_state_party_excludes_stale_players(monkeypatch):
+    g = oRPG.Game()
+    recent = oRPG.Player("Recent", "active", 1.0, [])
+    stale = oRPG.Player("Stale", "inactive", 1.0, [])
+    g.players = {recent.id: recent, stale.id: stale}
+
+    now = time.time()
+    recent.last_seen = now
+    stale.last_seen = now - 601
+
+    monkeypatch.setattr(oRPG, "GAME", g)
+
+    client = TestClient(oRPG.app)
+    resp = client.get("/state", params={"player_id": recent.id})
+    assert resp.status_code == 200
+    party = resp.json()["party"]
+    ids = [p["id"] for p in party]
+    assert recent.id in ids
+    assert stale.id not in ids


### PR DESCRIPTION
## Summary
- add regression test ensuring `/state` omits players inactive for over 600 seconds

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd426fcbd4832686021a014fdfc017