### PR TITLE
Add runtime toggle test for resolve permissions

### DIFF
--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -53,3 +53,25 @@ def test_state_can_resolve_when_anyone_allowed(monkeypatch):
     assert resp.status_code == 200
     data = resp.json()
     assert data["can_resolve"] is True
+
+
+def test_state_can_resolve_reflects_runtime_toggle(monkeypatch):
+    g = oRPG.Game()
+    host = oRPG.Player("Host", "leader", 1.0, [])
+    other = oRPG.Player("Other", "member", 1.0, [])
+    g.players = {host.id: host, other.id: other}
+    g.host_id = host.id
+    g.turn_number = 1
+
+    monkeypatch.setattr(oRPG, "GAME", g)
+    client = TestClient(oRPG.app)
+
+    monkeypatch.setattr(oRPG, "ALLOW_ANYONE_TO_RESOLVE", True)
+    resp = client.get("/state", params={"player_id": other.id})
+    assert resp.status_code == 200
+    assert resp.json()["can_resolve"] is True
+
+    monkeypatch.setattr(oRPG, "ALLOW_ANYONE_TO_RESOLVE", False)
+    resp2 = client.get("/state", params={"player_id": other.id})
+    assert resp2.status_code == 200
+    assert resp2.json()["can_resolve"] is False


### PR DESCRIPTION
## Summary
- add a test verifying `/state.can_resolve` follows runtime changes to `ALLOW_ANYONE_TO_RESOLVE`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd42739ba48326bd62ec8387d0db19