### PR TITLE
test: ensure snapshot helpers scale

### DIFF
--- a/tests/test_snapshot_scalability.py
+++ b/tests/test_snapshot_scalability.py
@@ -1,0 +1,22 @@
+import sys, pathlib
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+
+import oRPG
+
+
+def test_snapshots_handle_many_players(monkeypatch):
+    g = oRPG.Game()
+    players = []
+    actions = {}
+    for i in range(150):
+        p = oRPG.Player(f"Player{i}", "background", 1.0, [f"Ability{i}"])
+        g.players[p.id] = p
+        players.append(p)
+        actions[p.id] = f"action {i}"
+    monkeypatch.setattr(oRPG, "GAME", g)
+
+    party_out = oRPG.party_snapshot(players)
+    assert len(party_out.splitlines()) == len(players)
+
+    actions_out = oRPG.actions_snapshot(actions)
+    assert len(actions_out.splitlines()) == len(actions)


### PR DESCRIPTION
## Summary
- add regression test verifying snapshot helpers handle 150 players/actions without errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bd4277bc508326a9f89d51080a58d5