### PR TITLE
Fix indentation in archetype tests

### DIFF
--- a/tests/test_archetype.py
+++ b/tests/test_archetype.py
@@ -1,22 +1,25 @@
-import sys, pathlib
-sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+import sys
+import pathlib
 
 import pytest
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
 
 from oRPG import archetype_for_background
 
 
-@pytest.mark.parametrize("bg,expected", [
-    ("Mystic sorceress exploring ruins", "Mage"),
-    ("Silent THIEF from the city", "Rogue"),
-    ("An elven archer guarding the forest", "Ranger"),
-    ("Devout priest spreading light", "Cleric"),
-    ("BARBARIAN warrior of the north", "Warrior"),
-    ("A simple farmer with no special training", "Adventurer"),
-    ("", "Adventurer"),
-])
-
-
+@pytest.mark.parametrize(
+    "bg,expected",
+    [
+        ("Mystic sorceress exploring ruins", "Mage"),
+        ("Silent THIEF from the city", "Rogue"),
+        ("An elven archer guarding the forest", "Ranger"),
+        ("Devout priest spreading light", "Cleric"),
+        ("BARBARIAN warrior of the north", "Warrior"),
+        ("A simple farmer with no special training", "Adventurer"),
+        ("", "Adventurer"),
+    ],
+)
 def test_archetype_for_background(bg, expected):
     assert archetype_for_background(bg) == expected
 
@@ -25,23 +28,20 @@ def test_archetype_for_background(bg, expected):
 def test_archetype_warrior_keywords_case_insensitive(bg):
     assert archetype_for_background(bg) == "Warrior"
 
-    
-@pytest.mark.parametrize("bg", [
-    "cLeRiC",
-    "PrIeSt",
-    "pALaDiN",
-])
+
+@pytest.mark.parametrize(
+    "bg",
+    ["cLeRiC", "PrIeSt", "pALaDiN"],
+)
 def test_cleric_variations(bg):
     assert archetype_for_background(bg) == "Cleric"
 
-    
+
 @pytest.mark.parametrize("bg", ["RANGER", "HUNTER", "ARCHER"])
-
-
 def test_ranger_synonyms_case_insensitive(bg):
     assert archetype_for_background(bg) == "Ranger"
 
-    
+
 @pytest.mark.parametrize(
     "bg",
     [
@@ -51,10 +51,13 @@ def test_ranger_synonyms_case_insensitive(bg):
         "sPy gathering intel",
     ],
 )
-
-
 def test_archetype_stealth_keywords(bg):
     assert archetype_for_background(bg) == "Rogue"
+
+
+@pytest.mark.parametrize(
+    "bg",
+    [
         "A wandering MAGE seeking knowledge",
         "The wise wizard of the north",
         "An enigmatic SoRcErEr's apprentice",
@@ -63,3 +66,4 @@ def test_archetype_stealth_keywords(bg):
 )
 def test_spellcaster_keywords_map_to_mage(bg):
     assert archetype_for_background(bg) == "Mage"
+


### PR DESCRIPTION
## Summary
- restructure `tests/test_archetype.py` to remove indentation errors and properly parametrize archetype tests

## Testing
- `pytest -q` *(fails: test_do_resolution_history_and_state, test_join_assigns_abilities_based_on_background, test_state_party_excludes_stale_players)*

------
https://chatgpt.com/codex/tasks/task_e_68bd62cb1f748326a29f12694744c28c